### PR TITLE
add line numbers in error messages

### DIFF
--- a/sexp/decode.go
+++ b/sexp/decode.go
@@ -109,13 +109,13 @@ func decodeSkip(s *Scanner) error {
 					return nil
 				}
 			case EOF:
-				return fmt.Errorf("unexpected EOF while skipping tuple")
+				return fmt.Errorf("line %d: unexpected EOF while skipping tuple", s.lines)
 			}
 		}
 	}
 
 	if next.Type == RIGHT || next.Type == EOF {
-		return fmt.Errorf("no value to skip! found %s", next.Type)
+		return fmt.Errorf("line %d: no value to skip! found %s", s.lines, next.Type)
 	}
 
 	s.Read() // consume single-token value
@@ -137,7 +137,8 @@ func decodeString(s *Scanner, v reflect.Value) error {
 		v.SetString(str)
 	default:
 		return fmt.Errorf(
-			"unexpected %s while decoding into string",
+			"line %d: unexpected %s while decoding into string",
+			s.lines,
 			next.Type,
 		)
 	}
@@ -172,7 +173,8 @@ func decodeInt(s *Scanner, v reflect.Value) error {
 		}
 	default:
 		return fmt.Errorf(
-			"unexpected %s while decoding into int",
+			"line %d: unexpected %s while decoding into int",
+			s.lines,
 			next.Type,
 		)
 	}
@@ -194,7 +196,8 @@ func decodeFloat(s *Scanner, v reflect.Value) error {
 		v.SetFloat(val)
 	default:
 		return fmt.Errorf(
-			"unexpected %s while decoding into float",
+			"line %d: unexpected %s while decoding into float",
+			s.lines,
 			next.Type,
 		)
 	}
@@ -216,7 +219,8 @@ func decodeBool(s *Scanner, v reflect.Value) error {
 		v.SetBool(val)
 	default:
 		return fmt.Errorf(
-			"unexpected %s while decoding into bool",
+			"line %d: unexpected %s while decoding into bool",
+			s.lines,
 			next.Type,
 		)
 	}
@@ -230,7 +234,7 @@ func decodeSlice(s *Scanner, v reflect.Value) error {
 	next := s.Peek()
 	if next.Type != LEFT {
 		return fmt.Errorf(
-			"slice value cannot begin with %s", next.Type,
+			"line %d: slice value cannot begin with %s", s.lines, next.Type,
 		)
 	}
 	s.Read() // consume parenthesis
@@ -257,7 +261,7 @@ func decodeSequenceIntoSlice(s *Scanner, v reflect.Value, endType TokenType) err
 		}
 		if next.Type == EOF {
 			return fmt.Errorf(
-				"unexpected EOF while decoding slice value",
+				"line %d: unexpected EOF while decoding slice value", s.lines,
 			)
 		}
 
@@ -279,7 +283,7 @@ func decodeMap(s *Scanner, v reflect.Value) error {
 	next := s.Peek()
 	if next.Type != LEFT {
 		return fmt.Errorf(
-			"map value cannot begin with %s", next.Type,
+			"line %d: map value cannot begin with %s", s.lines, next.Type,
 		)
 	}
 	s.Read() // consume parenthesis
@@ -296,13 +300,13 @@ func decodeMap(s *Scanner, v reflect.Value) error {
 		}
 		if next.Type == EOF {
 			return fmt.Errorf(
-				"unexpected EOF while decoding slice value",
+				"line %d: unexpected EOF while decoding slice value", s.lines,
 			)
 		}
 
 		if next.Type != LEFT {
 			return fmt.Errorf(
-				"map entry must be tuple, but got %s", next.Type,
+				"line %d: map entry must be tuple, but got %s", s.lines, next.Type,
 			)
 		}
 
@@ -317,19 +321,19 @@ func decodeMap(s *Scanner, v reflect.Value) error {
 		}
 
 		if s.Peek().Type == RIGHT {
-			return fmt.Errorf("map entry tuples must have two elements")
+			return fmt.Errorf("line %d: map entry tuples must have two elements", s.lines)
 		}
 		if s.Peek().Type == EOF {
-			return fmt.Errorf("unexpected EOF while decoding map entry")
+			return fmt.Errorf("line %d: unexpected EOF while decoding map entry", s.lines)
 		}
 
 		err = decodeIntoValue(s, val)
 		if err != nil {
-			return err
+			return fmt.Errorf("line %d: %w", s.lines, err)
 		}
 
 		if s.Peek().Type != RIGHT {
-			return fmt.Errorf("map entry tuples must have two elements")
+			return fmt.Errorf("line %d: map entry tuples must have two elements", s.lines)
 		}
 		s.Read() // Consume closing paren
 
@@ -345,7 +349,7 @@ func decodeStruct(s *Scanner, v reflect.Value) error {
 	next := s.Peek()
 	if next.Type != LEFT {
 		return fmt.Errorf(
-			"struct value cannot begin with %s", next.Type,
+			"line %d: struct value cannot begin with %s", s.lines, next.Type,
 		)
 	}
 	s.Read() // consume parenthesis
@@ -393,8 +397,8 @@ func decodeSequenceIntoStruct(s *Scanner, v reflect.Value, endType TokenType) er
 				fieldDef.Multi = true
 			default:
 				return fmt.Errorf(
-					"invalid kicad decode flag %q on %s",
-					flag, field.Name,
+					"line %d: invalid kicad decode flag %q on %s",
+					s.lines, flag, field.Name,
 				)
 			}
 		}
@@ -402,7 +406,7 @@ func decodeSequenceIntoStruct(s *Scanner, v reflect.Value, endType TokenType) er
 		chkType := field.Type
 		if fieldDef.Multi {
 			if chkType.Kind() != reflect.Slice {
-				return fmt.Errorf("'multi' flag used on non-slice field %s", field.Name)
+				return fmt.Errorf("line %d: 'multi' flag used on non-slice field %s", s.lines, field.Name)
 			}
 			chkType = chkType.Elem()
 		}
@@ -410,7 +414,7 @@ func decodeSequenceIntoStruct(s *Scanner, v reflect.Value, endType TokenType) er
 		if fieldDef.Flat {
 			kind := chkType.Kind()
 			if kind != reflect.Slice && kind != reflect.Struct {
-				return fmt.Errorf("'flat' flag cannot be used on non-slice, non-struct field %s", field.Name)
+				return fmt.Errorf("line %d: 'flat' flag cannot be used on non-slice, non-struct field %s", s.lines, field.Name)
 			}
 		}
 
@@ -428,7 +432,7 @@ func decodeSequenceIntoStruct(s *Scanner, v reflect.Value, endType TokenType) er
 			break
 		}
 		if next.Type == EOF {
-			return fmt.Errorf("unexpected EOF decoding struct value")
+			return fmt.Errorf("line %d: unexpected EOF decoding struct value", s.lines)
 		}
 
 		var fieldDef *Field
@@ -439,8 +443,8 @@ func decodeSequenceIntoStruct(s *Scanner, v reflect.Value, endType TokenType) er
 		} else {
 			if next.Type != LEFT {
 				return fmt.Errorf(
-					"named struct field must start with LEFT, but got %s",
-					next.Type,
+					"line %d: named struct field must start with LEFT, but got %s (context: %+v)",
+					s.lines, next.Type, next,
 				)
 			}
 			s.Read() // consume parenthesis
@@ -448,8 +452,8 @@ func decodeSequenceIntoStruct(s *Scanner, v reflect.Value, endType TokenType) er
 			label := s.Peek()
 			if label.Type != RAW_STRING {
 				return fmt.Errorf(
-					"struct name must be RAW_STRING, but got %s",
-					label.Type,
+					"line %d: struct name must be RAW_STRING, but got %s",
+					s.lines, label.Type,
 				)
 			}
 			s.Read() // consume label
@@ -522,7 +526,8 @@ func decodeSequenceIntoStruct(s *Scanner, v reflect.Value, endType TokenType) er
 			close := s.Read()
 			if close.Type != RIGHT {
 				return fmt.Errorf(
-					"missing closing paren for struct tuple; got %s",
+					"line %d: missing closing paren for struct tuple; got %s",
+					s.lines,
 					close.Type,
 				)
 			}

--- a/sexp/scanner.go
+++ b/sexp/scanner.go
@@ -9,6 +9,7 @@ import (
 type Scanner struct {
 	s      *bufio.Scanner
 	peeked *Token
+	lines  int
 	eof    bool
 }
 
@@ -46,7 +47,8 @@ func (b scanError) Error() string {
 // NewScanner creates a new scanner that finds tokens in the given reader.
 func NewScanner(r io.Reader) *Scanner {
 	ret := &Scanner{
-		s: bufio.NewScanner(r),
+		lines: 1,
+		s:     bufio.NewScanner(r),
 	}
 	ret.s.Split(ret.findToken)
 	return ret
@@ -176,7 +178,10 @@ Bytes:
 		b = b[1:]
 
 		switch next {
-		case 10, 13, 32, 8, 0:
+		case 10:
+			s.lines++
+			size++
+		case 13, 32, 8, 0:
 			size++
 		default:
 			break Bytes
@@ -217,7 +222,7 @@ Bytes:
 	for {
 		if len(b) == 0 {
 			if eof {
-				return 0, nil, fmt.Errorf("unexpected EOF in string %q", data)
+				return 0, nil, fmt.Errorf("line %d: unexpected EOF in string %q", s.lines, data)
 			}
 
 			// Request more bytes


### PR DESCRIPTION
this makes tracking down problems significantly easier, particularly when defining new structures to match a given input

perhaps a `Scanner.Errorf()` function that includes line# and possibly also the next token might be better and less repeaty? but this works well enough